### PR TITLE
Update node modules + Fix send Html Email method + Bump version

### DIFF
--- a/machines/send-html-email.js
+++ b/machines/send-html-email.js
@@ -67,8 +67,7 @@ module.exports = {
 
     var util = require('util');
     var Mailgun = require('mailgun-js');
-    var MailComposer = require('mailcomposer').MailComposer;
-    var mailcomposer = new MailComposer();
+    var mailcomposer = require('mailcomposer');
 
     var mailgun = Mailgun({apiKey: inputs.apiKey, domain: inputs.domain});
 
@@ -101,7 +100,7 @@ module.exports = {
     // Strip off last comma
     to = to.slice(0, - 1);
 
-    mailcomposer.setMessageOption({
+    var mail = mailcomposer({
       from: from,
       to: to,
       subject: inputs.subject || 'Hello',
@@ -109,11 +108,11 @@ module.exports = {
       html: inputs.htmlMessage || ''
     });
 
-    mailcomposer.buildMessage(function(mailBuildError, messageSource) {
+    mail.build(function(mailBuildError, message) {
 
       var dataToSend = {
         to: to,
-        message: messageSource
+        message: message.toString('ascii')
       };
 
       mailgun.messages().sendMime(dataToSend, function (err, body) {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
     "machines",
     "machinepack"
   ],
-  "author": {
-    "name": "Mike McNeil",
-    "email": "mikermcneil"
-  },
+  "author": "Mike McNeil <mikermcneil>",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mikermcneil/machinepack-mailgun.git"
+    "url": "git@github.com:mikermcneil/machinepack-mailgun.git"
   },
   "license": "MIT",
   "dependencies": {
@@ -36,47 +33,5 @@
       "send-html-email"
     ],
     "testsUrl": "https://travis-ci.org/mikermcneil/machinepack-mailgun"
-  },
-  "gitHead": "6c61deb00cf1e087cbe2e4080d8e2154338498bf",
-  "bugs": {
-    "url": "https://github.com/mikermcneil/machinepack-mailgun/issues"
-  },
-  "homepage": "https://github.com/mikermcneil/machinepack-mailgun#readme",
-  "_id": "machinepack-mailgun@0.4.0",
-  "_shasum": "59c960e4ef6db98897d44aca564d6c804e1d878e",
-  "_from": "machinepack-mailgun@0.4.0",
-  "_npmVersion": "2.12.0",
-  "_nodeVersion": "0.10.37",
-  "_npmUser": {
-    "name": "particlebanana",
-    "email": "particlebanana@gmail.com"
-  },
-  "maintainers": [
-    {
-      "name": "balderdashy",
-      "email": "mike@balderdash.co"
-    },
-    {
-      "name": "sgress454",
-      "email": "scott@balderdash.co"
-    },
-    {
-      "name": "particlebanana",
-      "email": "particlebanana@gmail.com"
-    },
-    {
-      "name": "mikermcneil",
-      "email": "michael.r.mcneil@gmail.com"
-    },
-    {
-      "name": "irl",
-      "email": "irlnathan@gmail.com"
-    }
-  ],
-  "dist": {
-    "shasum": "59c960e4ef6db98897d44aca564d6c804e1d878e",
-    "tarball": "http://registry.npmjs.org/machinepack-mailgun/-/machinepack-mailgun-0.4.0.tgz"
-  },
-  "directories": {},
-  "_resolved": "https://registry.npmjs.org/machinepack-mailgun/-/machinepack-mailgun-0.4.0.tgz"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-mailgun",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Machines for the Mailgun API.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"
@@ -10,16 +10,19 @@
     "machines",
     "machinepack"
   ],
-  "author": "Mike McNeil <mikermcneil>",
+  "author": {
+    "name": "Mike McNeil",
+    "email": "mikermcneil"
+  },
   "repository": {
     "type": "git",
-    "url": "git@github.com:mikermcneil/machinepack-mailgun.git"
+    "url": "git+ssh://git@github.com/mikermcneil/machinepack-mailgun.git"
   },
   "license": "MIT",
   "dependencies": {
-    "machine": "^10.3.1",
-    "mailcomposer": "^0.2.12",
-    "mailgun-js": "^0.6.7"
+    "machine": "^11.0.3",
+    "mailcomposer": "^2.1.0",
+    "mailgun-js": "^0.7.2"
   },
   "devDependencies": {
     "mocha": "^2.1.0",
@@ -33,5 +36,47 @@
       "send-html-email"
     ],
     "testsUrl": "https://travis-ci.org/mikermcneil/machinepack-mailgun"
-  }
+  },
+  "gitHead": "6c61deb00cf1e087cbe2e4080d8e2154338498bf",
+  "bugs": {
+    "url": "https://github.com/mikermcneil/machinepack-mailgun/issues"
+  },
+  "homepage": "https://github.com/mikermcneil/machinepack-mailgun#readme",
+  "_id": "machinepack-mailgun@0.4.0",
+  "_shasum": "59c960e4ef6db98897d44aca564d6c804e1d878e",
+  "_from": "machinepack-mailgun@0.4.0",
+  "_npmVersion": "2.12.0",
+  "_nodeVersion": "0.10.37",
+  "_npmUser": {
+    "name": "particlebanana",
+    "email": "particlebanana@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "balderdashy",
+      "email": "mike@balderdash.co"
+    },
+    {
+      "name": "sgress454",
+      "email": "scott@balderdash.co"
+    },
+    {
+      "name": "particlebanana",
+      "email": "particlebanana@gmail.com"
+    },
+    {
+      "name": "mikermcneil",
+      "email": "michael.r.mcneil@gmail.com"
+    },
+    {
+      "name": "irl",
+      "email": "irlnathan@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "59c960e4ef6db98897d44aca564d6c804e1d878e",
+    "tarball": "http://registry.npmjs.org/machinepack-mailgun/-/machinepack-mailgun-0.4.0.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/machinepack-mailgun/-/machinepack-mailgun-0.4.0.tgz"
 }


### PR DESCRIPTION
Hi!

I tried to use your module on Treeline, but the send Html Email method is broken (due to some module updates and Mailgun Mime API).

I fixed the method + updated the modules + bumped the version to 0.5.0.

You just have to merged + npm publish and it's done :)

Thank you!
